### PR TITLE
git subtree から git submodule に取り込み方式を変更

### DIFF
--- a/CLAUDE_CODE_REFERENCE.md
+++ b/CLAUDE_CODE_REFERENCE.md
@@ -44,11 +44,11 @@
 テンプレートに更新が入った場合、以下で最新版を反映できます：
 
 ```bash
-git subtree pull --prefix=.claude/vibe-coding-utils https://github.com/machina-gg/vibe-coding-utils.git develop --squash
+git submodule update --remote
 bash .claude/vibe-coding-utils/scripts/setup-framework.sh <nextjs|chrome-extension>
 ```
 
-詳細: [Subtree セットアップガイド](./.claude/vibe-coding-utils/docs/shared/SETUP_SUBTREE.md)
+詳細: [Submodule セットアップガイド](./.claude/vibe-coding-utils/docs/shared/SETUP_SUBMODULE.md)
 
 ## ドキュメント構成
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Claude Code でバイブコーディングするためのテンプレートリポジトリです。
 
 AIに指示を出すだけで、要件定義から実装まで一貫したフォーマットで開発を進められます。
-`git subtree` で取り込むことで、複数プロジェクトでの再利用とテンプレート更新の反映が可能です。
+`git submodule` で取り込むことで、複数プロジェクトでの再利用とテンプレート更新の反映が可能です。
 
 ### 対応フレームワーク
 
@@ -20,7 +20,7 @@ AIに指示を出すだけで、要件定義から実装まで一貫したフォ
 
 ```bash
 # プロジェクトのルートディレクトリで実行
-git subtree add --prefix=.claude/vibe-coding-utils https://github.com/machina-gg/vibe-coding-utils.git develop --squash
+git submodule add -b develop https://github.com/machina-gg/vibe-coding-utils.git .claude/vibe-coding-utils
 ```
 
 ### 2. フレームワークを選択してセットアップ
@@ -43,7 +43,7 @@ bash .claude/vibe-coding-utils/scripts/setup-framework.sh chrome-extension
 6. `/project:implement` で本実装
 7. `/project:deploy` でデプロイ
 
-テンプレートの更新方法やチームメンバーの設定は [Subtree セットアップガイド](./docs/shared/SETUP_SUBTREE.md) を参照してください。
+テンプレートの更新方法やチームメンバーの設定は [Submodule セットアップガイド](./docs/shared/SETUP_SUBMODULE.md) を参照してください。
 
 ## What's Included
 
@@ -101,7 +101,7 @@ Claude Code で以下のスラッシュコマンドが使用可能です：
 | -------- | ---- |
 | [CLAUDE_CODE_REFERENCE.md](./CLAUDE_CODE_REFERENCE.md) | Claude Code 操作リファレンス |
 | [CONTRIBUTING.md](./CONTRIBUTING.md) | コントリビューションガイド |
-| [Subtree セットアップ](./docs/shared/SETUP_SUBTREE.md) | 取り込み・更新手順 |
+| [Submodule セットアップ](./docs/shared/SETUP_SUBMODULE.md) | 取り込み・更新手順 |
 | [開発フロー](./docs/shared/DEVELOPMENT_FLOW.md) | 開発フロー図 |
 | [GitHub MCP 設定](./docs/shared/SETUP_GITHUB_MCP.md) | Issue 管理の設定 |
 | [権限設定](./docs/shared/SETUP_PERMISSIONS.md) | コミット・PR確認スキップ |

--- a/docs/shared/SETUP_SUBMODULE.md
+++ b/docs/shared/SETUP_SUBMODULE.md
@@ -1,14 +1,14 @@
-# Subtree セットアップガイド
+# Submodule セットアップガイド
 
 vibe-coding-utils をプロジェクトに取り込むための手順です。
 
 ---
 
-## 1. subtree で取り込む
+## 1. submodule で取り込む
 
 ```bash
 # プロジェクトのルートディレクトリで実行
-git subtree add --prefix=.claude/vibe-coding-utils https://github.com/machina-gg/vibe-coding-utils.git develop --squash
+git submodule add -b develop https://github.com/machina-gg/vibe-coding-utils.git .claude/vibe-coding-utils
 ```
 
 これにより `.claude/vibe-coding-utils/` 配下にテンプレートが配置されます。
@@ -42,7 +42,7 @@ bash .claude/vibe-coding-utils/scripts/setup-framework.sh chrome-extension
 
 ```bash
 # 最新版を取得
-git subtree pull --prefix=.claude/vibe-coding-utils https://github.com/machina-gg/vibe-coding-utils.git develop --squash
+git submodule update --remote
 
 # セットアップを再実行（コマンドとCLAUDE.mdを再生成）
 bash .claude/vibe-coding-utils/scripts/setup-framework.sh nextjs
@@ -57,13 +57,14 @@ bash .claude/vibe-coding-utils/scripts/setup-framework.sh nextjs
 ```
 your-project/
 ├── .claude/
-│   ├── vibe-coding-utils/    # subtree で取り込んだテンプレート（編集しない）
+│   ├── vibe-coding-utils/    # submodule で取り込んだテンプレート（編集しない）
 │   │   ├── templates/
 │   │   ├── commands/
 │   │   ├── docs/
 │   │   └── scripts/
 │   └── commands/
 │       └── project/          # setup-framework.sh で生成されたコマンド
+├── .gitmodules               # submodule の設定ファイル
 ├── CLAUDE.md                 # setup-framework.sh で生成された指示書
 ├── docs/                     # プロジェクト固有のドキュメント
 │   └── INPUT.md              # setup-framework.sh で生成
@@ -74,7 +75,19 @@ your-project/
 
 ## 5. チームメンバーの環境構築
 
-`CLAUDE.md` と `.claude/commands/project/` はコミットに含まれるため、リポジトリをクローンするだけで Claude Code の指示書とコマンド（`/project:*`）が使えます。
+リポジトリをクローンする際は `--recursive` オプションを付けて submodule も取得します：
+
+```bash
+git clone --recursive <repository-url>
+```
+
+既にクローン済みの場合は以下で submodule を取得できます：
+
+```bash
+git submodule update --init
+```
+
+`CLAUDE.md` と `.claude/commands/project/` はコミットに含まれるため、クローンするだけで Claude Code の指示書とコマンド（`/project:*`）が使えます。
 
 テンプレートの更新を反映したい場合は、セットアップスクリプトを再実行してください：
 
@@ -84,7 +97,21 @@ bash .claude/vibe-coding-utils/scripts/setup-framework.sh <nextjs|chrome-extensi
 
 ---
 
+## 6. CI/CD での注意事項
+
+CI/CD パイプラインで submodule を使用する場合は、チェックアウト時に `--recursive` オプションを追加してください。
+
+**GitHub Actions の場合：**
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    submodules: recursive
+```
+
+---
+
 ## 注意事項
 
-- `.claude/vibe-coding-utils/` 内のファイルは直接編集しない（subtree pull で上書きされるため）
+- `.claude/vibe-coding-utils/` 内のファイルは直接編集しない（submodule update で上書きされるため）
 - `CLAUDE.md` はテンプレートから生成されるものをそのまま使用する想定です。テンプレート更新時に `setup-framework.sh` で再生成・上書きされます

--- a/scripts/setup-framework.sh
+++ b/scripts/setup-framework.sh
@@ -36,8 +36,8 @@ esac
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# プロジェクトルートを特定（subtree の場合は .claude/vibe-coding-utils/ の2つ上）
-# スクリプトが直接実行される場合と subtree 経由の場合の両方に対応
+# プロジェクトルートを特定（submodule の場合は .claude/vibe-coding-utils/ の2つ上）
+# スクリプトが直接実行される場合と submodule 経由の場合の両方に対応
 if [[ "$BASE_DIR" == *".claude/vibe-coding-utils"* ]]; then
   PROJECT_ROOT="$(cd "$BASE_DIR/../.." && pwd)"
 else


### PR DESCRIPTION
## Summary
- README.md の Quick Start を `git submodule` 方式に変更
- `docs/shared/SETUP_SUBTREE.md` を `SETUP_SUBMODULE.md` にリネーム・内容更新
- CLAUDE_CODE_REFERENCE.md のテンプレート更新手順を submodule 方式に変更
- CI/CD（GitHub Actions）での `--recursive` 設定例を追記
- `setup-framework.sh` のコメントを更新

## Test plan
- [ ] README.md の Quick Start 手順が submodule コマンドになっていることを確認
- [ ] SETUP_SUBMODULE.md のクローン・更新・CI/CD手順が正しいことを確認
- [ ] CLAUDE_CODE_REFERENCE.md のリンクが SETUP_SUBMODULE.md を指していることを確認
- [ ] 旧 SETUP_SUBTREE.md が削除されていることを確認

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)