### PR TITLE
implement.mdのworktree操作をcd不要に変更し、cleanup.mdを新設

### DIFF
--- a/commands/chrome-extension/implement.md
+++ b/commands/chrome-extension/implement.md
@@ -43,8 +43,7 @@ git worktree add ../プロジェクト名-XX -b feature/#XX origin/develop
 package.json が存在する場合：
 
 ```bash
-cd ../プロジェクト名-XX
-pnpm install
+pnpm --dir ../プロジェクト名-XX install
 ```
 
 ### 3. GitHub Issue の内容を確認
@@ -71,10 +70,10 @@ pnpm install
 ### 7. lint / format / テスト実行
 
 ```bash
-pnpm format
-pnpm lint
-pnpm test
-pnpm test:e2e
+pnpm --dir ../プロジェクト名-XX format
+pnpm --dir ../プロジェクト名-XX lint
+pnpm --dir ../プロジェクト名-XX test
+pnpm --dir ../プロジェクト名-XX test:e2e
 ```
 
 ### 8. ドキュメント更新（該当する場合）
@@ -85,6 +84,7 @@ pnpm test:e2e
 
 ### 9. コミット・プッシュ・PR作成
 
+- `git -C ../プロジェクト名-XX` でコマンドを実行する
 - コミットメッセージに `Closes #XX` を含める
 - 例: `Prettier設定を変更 Closes #34`
 - PR を作成する（PRマージ時にIssueが自動クローズされる）
@@ -98,12 +98,10 @@ gh pr checks <PR番号> --watch
 - **成功**: 次のステップへ
 - **失敗**: エラー内容を確認し、修正してプッシュ → 再度CIを待つ
 
-### 11. worktree を削除
+### 11. 完了
 
-```bash
-cd ../プロジェクト名
-git worktree remove ../プロジェクト名-XX
-```
+- worktree はこのタイミングでは削除しない（CI失敗時の追加修正に備える）
+- マージ後のクリーンアップは `/project:cleanup` で一括実行する
 
 ## コミットメッセージ規則
 

--- a/commands/nextjs/implement.md
+++ b/commands/nextjs/implement.md
@@ -43,8 +43,7 @@ git worktree add ../プロジェクト名-XX -b feature/#XX origin/develop
 package.json が存在する場合：
 
 ```bash
-cd ../プロジェクト名-XX
-npm install
+npm install --prefix ../プロジェクト名-XX
 ```
 
 ### 3. GitHub Issue の内容を確認
@@ -71,10 +70,10 @@ npm install
 ### 7. lint / format / テスト実行
 
 ```bash
-npm run format
-npm run lint
-npm run test
-npm run test:e2e
+npm run --prefix ../プロジェクト名-XX format
+npm run --prefix ../プロジェクト名-XX lint
+npm run --prefix ../プロジェクト名-XX test
+npm run --prefix ../プロジェクト名-XX test:e2e
 ```
 
 ### 8. ドキュメント更新（該当する場合）
@@ -85,6 +84,7 @@ npm run test:e2e
 
 ### 9. コミット・プッシュ・PR作成
 
+- `git -C ../プロジェクト名-XX` でコマンドを実行する
 - コミットメッセージに `Closes #XX` を含める
 - 例: `Prettier設定を変更 Closes #34`
 - PR を作成する（PRマージ時にIssueが自動クローズされる）
@@ -98,12 +98,10 @@ gh pr checks <PR番号> --watch
 - **成功**: 次のステップへ
 - **失敗**: エラー内容を確認し、修正してプッシュ → 再度CIを待つ
 
-### 11. worktree を削除
+### 11. 完了
 
-```bash
-cd ../プロジェクト名
-git worktree remove ../プロジェクト名-XX
-```
+- worktree はこのタイミングでは削除しない（CI失敗時の追加修正に備える）
+- マージ後のクリーンアップは `/project:cleanup` で一括実行する
 
 ## コミットメッセージ規則
 

--- a/commands/shared/cleanup.md
+++ b/commands/shared/cleanup.md
@@ -1,0 +1,63 @@
+---
+description: マージ済みブランチと worktree をクリーンアップする
+---
+
+以下の手順でマージ済みブランチと worktree のクリーンアップを行ってください：
+
+## 1. リモートの最新状態を取得
+
+```bash
+git fetch origin --prune
+```
+
+## 2. マージ済みブランチの検出
+
+develop にマージ済みの `feature/#*` ブランチを一覧取得する：
+
+```bash
+git branch --merged origin/develop --list 'feature/#*'
+```
+
+## 3. 対象一覧の表示とユーザー確認
+
+検出結果をユーザーに表示する：
+
+- マージ済みブランチ一覧（削除対象）
+- 対応する worktree の有無
+- 未マージのブランチがあれば警告として表示（削除しない）
+
+未マージブランチの確認：
+
+```bash
+git branch --no-merged origin/develop --list 'feature/#*'
+```
+
+**ユーザーの確認を得てから次のステップに進むこと。**
+
+## 4. worktree の削除
+
+マージ済みブランチに対応する worktree が存在する場合、削除する：
+
+```bash
+git worktree list
+```
+
+対応する worktree があれば：
+
+```bash
+git worktree remove ../プロジェクト名-XX
+```
+
+## 5. ローカルブランチの削除
+
+マージ済みブランチを削除する：
+
+```bash
+git branch -d feature/#XX
+```
+
+## 6. 結果の報告
+
+- 削除した worktree の一覧
+- 削除したブランチの一覧
+- 未マージのため残したブランチの一覧（該当する場合）


### PR DESCRIPTION
## Summary

- implement.md（nextjs / chrome-extension）の worktree 操作手順を `cd` 不要に変更し、worktree 削除後に bash セッションが壊れる問題を解消
- worktree 削除を implement フローから分離し、CI 失敗時の追加修正を可能に
- `/project:cleanup` コマンドを新設し、マージ済みブランチ・worktree の一括クリーンアップを実現

## Test plan

- [ ] `commands/nextjs/implement.md` に `cd ../` が worktree 移動に使われていないことを確認
- [ ] `commands/chrome-extension/implement.md` に `cd ../` が worktree 移動に使われていないことを確認
- [ ] `commands/shared/cleanup.md` のフローが正しいことを確認（マージ済み検出 → ユーザー確認 → worktree 削除 → ブランチ削除）

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)