### PR TITLE
/project:update コマンドを新設

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Claude Code で以下のスラッシュコマンドが使用可能です：
 | `/project:status`                | 現在の状況を確認                   |  o   |         |            |
 | `/project:review`                | コードレビューと修正               |  o   |         |            |
 | `/project:deploy`                | デプロイを行う                     |      |    o    |     o      |
+| `/project:cleanup`               | マージ済みブランチ・worktree を削除 |  o   |         |            |
+| `/project:update`                | vibe-coding-utils を最新化         |  o   |         |            |
 
 ## Workflow
 

--- a/commands/shared/update.md
+++ b/commands/shared/update.md
@@ -1,0 +1,51 @@
+---
+description: vibe-coding-utils を最新化する
+---
+
+以下の手順で vibe-coding-utils サブモジュールを最新化し、コマンドと CLAUDE.md を再生成してください：
+
+## 1. サブモジュールの更新
+
+```bash
+git submodule update --remote .claude/vibe-coding-utils
+```
+
+## 2. 更新内容の確認
+
+更新前後のコミット差分をユーザーに表示する：
+
+```bash
+git diff --submodule .claude/vibe-coding-utils
+```
+
+更新がない場合は「すでに最新です」と報告して終了。
+
+## 3. フレームワークの判定
+
+CLAUDE.md の技術スタックセクションからフレームワークを判定する：
+
+- `Plasmo` → `chrome-extension`
+- `Next.js` → `nextjs`
+
+## 4. セットアップスクリプトの再実行
+
+```bash
+bash .claude/vibe-coding-utils/scripts/setup-framework.sh <framework>
+```
+
+## 5. 差分の確認
+
+再生成されたファイルの差分を確認する：
+
+```bash
+git diff
+```
+
+変更内容をユーザーに報告する。
+
+## 6. コミット
+
+変更をコミットする：
+
+- サブモジュールの更新と再生成ファイルをまとめて1コミット
+- コミットメッセージ例: `chore: vibe-coding-utilsを最新化`

--- a/templates/CLAUDE_BASE.md
+++ b/templates/CLAUDE_BASE.md
@@ -59,6 +59,8 @@
 | `/project:status`                | 現在の状況を確認                           |
 | `/project:review`                | コードレビューと修正                       |
 | `/project:deploy`                | デプロイを行う                             |
+| `/project:cleanup`               | マージ済みブランチと worktree をクリーンアップ |
+| `/project:update`                | vibe-coding-utils を最新化                 |
 
 詳細は `.claude/commands/` 配下の各ファイルを参照。
 


### PR DESCRIPTION
## Summary

- `/project:update` コマンドを `commands/shared/update.md` に新設
- `CLAUDE_BASE.md` のコマンド一覧に `/project:update` と `/project:cleanup` を追加
- `README.md` の Commands テーブルに `/project:update` と `/project:cleanup` を追加

Closes #29
