### PR TITLE
生成ファイルを.gitignoreに追加してコミット対象から外す

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,17 @@ bash .claude/vibe-coding-utils/scripts/setup-framework.sh nextjs
 bash .claude/vibe-coding-utils/scripts/setup-framework.sh chrome-extension
 ```
 
-### 3. 開発を開始
+### 3. 生成ファイルについて
+
+`setup-framework.sh` は以下のファイルを生成します。これらは `.gitignore` に追加されるため、チームメンバーはクローン後にセットアップスクリプトを実行してください。
+
+| 生成ファイル | 内容 |
+| --- | --- |
+| `CLAUDE.md` | AI 指示書（テンプレートから結合生成） |
+| `CLAUDE_CODE_REFERENCE.md` | 操作リファレンス |
+| `.claude/commands/project/` | スラッシュコマンド一式 |
+
+### 4. 開発を開始
 
 1. `docs/INPUT.md` に作りたいものを記載
 2. `/project:requirements` で要件定義

--- a/docs/shared/SETUP_SUBMODULE.md
+++ b/docs/shared/SETUP_SUBMODULE.md
@@ -87,13 +87,13 @@ git clone --recursive <repository-url>
 git submodule update --init
 ```
 
-`CLAUDE.md` と `.claude/commands/project/` はコミットに含まれるため、クローンするだけで Claude Code の指示書とコマンド（`/project:*`）が使えます。
-
-テンプレートの更新を反映したい場合は、セットアップスクリプトを再実行してください：
+`CLAUDE.md`・`CLAUDE_CODE_REFERENCE.md`・`.claude/commands/project/` は `.gitignore` で除外されているため、クローン後にセットアップスクリプトの実行が必要です：
 
 ```bash
 bash .claude/vibe-coding-utils/scripts/setup-framework.sh <nextjs|chrome-extension>
 ```
+
+これにより Claude Code の指示書とコマンド（`/project:*`）が生成されます。
 
 ---
 

--- a/scripts/setup-framework.sh
+++ b/scripts/setup-framework.sh
@@ -115,7 +115,10 @@ fi
 # 6. .gitignore に生成ファイルの除外パターンを追加（各行ごとに重複チェック）
 GITIGNORE="$PROJECT_ROOT/.gitignore"
 GITIGNORE_ENTRIES=(
+  ".claude/commands/project/"
   ".claude/tmp/"
+  "CLAUDE.md"
+  "CLAUDE_CODE_REFERENCE.md"
 )
 GITIGNORE_UPDATED=false
 for entry in "${GITIGNORE_ENTRIES[@]}"; do


### PR DESCRIPTION
## Summary

- `setup-framework.sh` の `.gitignore` 追記処理に `CLAUDE.md`、`CLAUDE_CODE_REFERENCE.md`、`.claude/commands/project/` を追加
- `SETUP_SUBMODULE.md` のチームメンバー環境構築手順を更新（クローン後に `setup-framework.sh` 実行が必要な旨を明記）
- `README.md` の Quick Start に生成ファイルの説明セクションを追加

## Test plan

- [ ] `setup-framework.sh` の `GITIGNORE_ENTRIES` に3つのエントリが追加されていることを確認
- [ ] `SETUP_SUBMODULE.md` でクローン後のセットアップスクリプト実行が必須である旨が記載されていることを確認
- [ ] `README.md` に生成ファイル一覧と説明が追加されていることを確認

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)