### PR TITLE
setup-framework.sh で settings.local.json を最小権限構成で自動生成

### DIFF
--- a/scripts/setup-framework.sh
+++ b/scripts/setup-framework.sh
@@ -68,7 +68,7 @@ rm -rf "$COMMANDS_DEST"
 mkdir -p "$COMMANDS_DEST"
 
 # 2. shared コマンドをコピー
-echo "[1/4] Copying shared commands..."
+echo "[1/5] Copying shared commands..."
 for file in "$BASE_DIR/commands/shared/"*.md; do
   if [ -f "$file" ]; then
     cp "$file" "$COMMANDS_DEST/"
@@ -77,7 +77,7 @@ for file in "$BASE_DIR/commands/shared/"*.md; do
 done
 
 # 3. フレームワーク固有コマンドをコピー
-echo "[2/4] Copying $FRAMEWORK commands..."
+echo "[2/5] Copying $FRAMEWORK commands..."
 for file in "$BASE_DIR/commands/$FRAMEWORK/"*.md; do
   if [ -f "$file" ]; then
     cp "$file" "$COMMANDS_DEST/"
@@ -86,7 +86,7 @@ for file in "$BASE_DIR/commands/$FRAMEWORK/"*.md; do
 done
 
 # 4. CLAUDE.md を生成（BASE + フレームワーク固有を結合）
-echo "[3/5] Generating CLAUDE.md..."
+echo "[3/6] Generating CLAUDE.md..."
 CLAUDE_MD="$PROJECT_ROOT/CLAUDE.md"
 
 cat "$BASE_DIR/templates/CLAUDE_BASE.md" > "$CLAUDE_MD"
@@ -96,12 +96,12 @@ cat "$BASE_DIR/templates/$CLAUDE_TEMPLATE" >> "$CLAUDE_MD"
 echo "  -> CLAUDE.md generated"
 
 # 5. CLAUDE_CODE_REFERENCE.md をコピー
-echo "[4/5] Copying CLAUDE_CODE_REFERENCE.md..."
+echo "[4/6] Copying CLAUDE_CODE_REFERENCE.md..."
 cp "$BASE_DIR/CLAUDE_CODE_REFERENCE.md" "$PROJECT_ROOT/CLAUDE_CODE_REFERENCE.md"
 echo "  -> CLAUDE_CODE_REFERENCE.md copied"
 
 # 6. docs/INPUT.md をコピー（存在しない場合のみ）
-echo "[5/5] Setting up project files..."
+echo "[5/6] Setting up project files..."
 DOCS_DIR="$PROJECT_ROOT/docs"
 mkdir -p "$DOCS_DIR"
 
@@ -112,7 +112,77 @@ else
   echo "  -> docs/INPUT.md already exists, skipping"
 fi
 
-# 6. .gitignore に生成ファイルの除外パターンを追加（各行ごとに重複チェック）
+# 6. settings.local.json を生成（存在しない場合のみ）
+echo "[6/6] Generating settings.local.json..."
+SETTINGS_LOCAL="$PROJECT_ROOT/.claude/settings.local.json"
+
+# フレームワーク別のパッケージマネージャ許可
+case "$FRAMEWORK" in
+  nextjs)
+    PKG_MANAGER_PERMISSION='"Bash(npm *)"'
+    ;;
+  chrome-extension)
+    PKG_MANAGER_PERMISSION='"Bash(pnpm *)"'
+    ;;
+esac
+
+if [ ! -f "$SETTINGS_LOCAL" ]; then
+  mkdir -p "$(dirname "$SETTINGS_LOCAL")"
+  cat > "$SETTINGS_LOCAL" << SETTINGS_EOF
+{
+  "permissions": {
+    "allow": [
+      "WebSearch",
+      ${PKG_MANAGER_PERMISSION},
+      "Bash(npx *)",
+      "Bash(git add *)",
+      "Bash(git branch *)",
+      "Bash(git checkout *)",
+      "Bash(git commit *)",
+      "Bash(git diff *)",
+      "Bash(git diff)",
+      "Bash(git fetch *)",
+      "Bash(git fetch)",
+      "Bash(git log *)",
+      "Bash(git pull *)",
+      "Bash(git push *)",
+      "Bash(git push)",
+      "Bash(git restore *)",
+      "Bash(git rm *)",
+      "Bash(git stash *)",
+      "Bash(git stash)",
+      "Bash(git status *)",
+      "Bash(git status)",
+      "Bash(git submodule *)",
+      "Bash(git worktree *)",
+      "Bash(gh issue create *)",
+      "Bash(gh issue close *)",
+      "Bash(gh issue comment *)",
+      "Bash(gh issue edit *)",
+      "Bash(gh issue list *)",
+      "Bash(gh issue view *)",
+      "Bash(gh pr checks *)",
+      "Bash(gh pr comment *)",
+      "Bash(gh pr create *)",
+      "Bash(gh pr edit *)",
+      "Bash(gh pr view *)",
+      "Bash(gh run view *)",
+      "Bash(gh api *)",
+      "Bash(bash .claude/vibe-coding-utils/*)",
+      "Bash(ls *)",
+      "Bash(mkdir -p src/*)",
+      "Bash(tree *)",
+      "Bash(find *)"
+    ]
+  }
+}
+SETTINGS_EOF
+  echo "  -> settings.local.json created"
+else
+  echo "  -> settings.local.json already exists, skipping"
+fi
+
+# 8. .gitignore に生成ファイルの除外パターンを追加（各行ごとに重複チェック）
 GITIGNORE="$PROJECT_ROOT/.gitignore"
 GITIGNORE_ENTRIES=(
   ".claude/commands/project/"
@@ -135,7 +205,7 @@ if [ "$GITIGNORE_UPDATED" = true ]; then
   echo "  -> .gitignore updated"
 fi
 
-# 7. .prettierignore に生成ファイルの除外パターンを追加（各行ごとに重複チェック）
+# 9. .prettierignore に生成ファイルの除外パターンを追加（各行ごとに重複チェック）
 PRETTIERIGNORE="$PROJECT_ROOT/.prettierignore"
 PRETTIERIGNORE_ENTRIES=(
   "CLAUDE.md"

--- a/scripts/setup-framework.sh
+++ b/scripts/setup-framework.sh
@@ -126,6 +126,12 @@ case "$FRAMEWORK" in
     ;;
 esac
 
+# worktree 用のパスパターンを生成（プロジェクト名-* にマッチ）
+PROJECT_NAME="$(basename "$PROJECT_ROOT")"
+PROJECT_PARENT="$(dirname "$PROJECT_ROOT")"
+# ホームディレクトリを ~ に置換して短縮
+WORKTREE_PATTERN="${PROJECT_PARENT/#$HOME/~}/${PROJECT_NAME}-*/**"
+
 if [ ! -f "$SETTINGS_LOCAL" ]; then
   mkdir -p "$(dirname "$SETTINGS_LOCAL")"
   cat > "$SETTINGS_LOCAL" << SETTINGS_EOF
@@ -172,7 +178,12 @@ if [ ! -f "$SETTINGS_LOCAL" ]; then
       "Bash(ls *)",
       "Bash(mkdir -p src/*)",
       "Bash(tree *)",
-      "Bash(find *)"
+      "Bash(find *)",
+      "Read(${WORKTREE_PATTERN})",
+      "Grep(${WORKTREE_PATTERN})",
+      "Glob(${WORKTREE_PATTERN})",
+      "Edit(${WORKTREE_PATTERN})",
+      "Write(${WORKTREE_PATTERN})"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- `setup-framework.sh` に `settings.local.json` の自動生成処理を追加
- フレームワーク別にパッケージマネージャの許可を切り替え（nextjs → npm, chrome-extension → pnpm）
- 既存ファイルがある場合はスキップ（`docs/INPUT.md` と同じ挙動）
- `.gitignore` に `settings.local.json` は既に含まれていることを確認済み

Closes #34

## Test plan
- [ ] `bash scripts/setup-framework.sh nextjs` で `settings.local.json` が生成され、`"Bash(npm *)"` が含まれることを確認
- [ ] `bash scripts/setup-framework.sh chrome-extension` で `settings.local.json` が生成され、`"Bash(pnpm *)"` が含まれることを確認
- [ ] 既に `settings.local.json` が存在する場合にスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)